### PR TITLE
Enhance examiner with features

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -258,9 +258,106 @@ p.answer.notselected:hover {
 
 #endScreen {
     position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    overflow-y: auto;
+    background: #222222;
+    padding: 3rem 2rem 0;
+}
+
+.pause-toggle-btn {
+    position: absolute;
+    right: 0.3rem;
     top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #959595;
+    font-size: 1rem;
+    padding: 0.1rem 0.3rem;
+    line-height: 1;
+}
+
+.pause-toggle-btn:hover {
+    color: white;
+}
+
+.timer.paused {
+    color: #959595;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    max-width: 860px;
+    margin: 1.5rem auto;
+}
+
+.stats-card {
+    background: #1a1a1a;
+    border-radius: 6px;
+    padding: 1.2rem 1rem;
+    text-align: center;
+}
+
+.stats-card-value {
+    display: block;
+    font-size: 2.2rem;
+    font-weight: bold;
+    color: white;
+}
+
+.stats-card-label {
+    display: block;
+    font-size: 0.8rem;
+    color: #959595;
+    margin-top: 0.3rem;
+}
+
+.stats-card.correct .stats-card-value { color: #4caf50; }
+.stats-card.wrong   .stats-card-value { color: #f44336; }
+.stats-card.corrected .stats-card-value { color: #ffc107; }
+.stats-card.skipped   .stats-card-value { color: #9c27b0; }
+
+.stats-section-title {
+    color: #959595;
+    text-align: center;
+    font-size: 1rem;
+    margin: 2rem 0 0.8rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.stats-table {
+    max-width: 860px;
+    margin: 0 auto;
+    width: 100%;
+    border-collapse: collapse;
+    color: white;
+    font-size: 0.9rem;
+}
+
+.stats-table th {
+    text-align: left;
+    color: #959595;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid #333;
+    font-weight: normal;
+}
+
+.stats-table td {
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid #1a1a1a;
+}
+
+.stats-table td:last-child {
+    text-align: center;
+    color: #f44336;
+    font-weight: bold;
 }
 
 #confirmButton {

--- a/css/index.css
+++ b/css/index.css
@@ -278,6 +278,63 @@ p.answer.notselected:hover {
     color: #959595;
     font-size: 1.1rem;
     padding: 0.4rem;
+    position: relative;
+}
+
+.search-toggle-btn {
+    position: absolute;
+    right: 0.3rem;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #959595;
+    padding: 0.1rem 0.3rem;
+    line-height: 0;
+}
+
+.search-toggle-btn:hover {
+    color: white;
+}
+
+.question-search-bar {
+    background: #0e0e0e;
+    padding: 0.35rem 0.5rem;
+    display: flex;
+    align-items: center;
+}
+
+.question-search-input {
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid #555;
+    color: white;
+    outline: none;
+    width: 100%;
+    font-size: 0.9rem;
+    padding: 0.1rem 0;
+}
+
+.question-search-input::placeholder {
+    color: #555;
+}
+
+.check-skip-row {
+    display: flex;
+    gap: 4px;
+}
+
+.check-skip-row #checkButton {
+    flex: 1;
+    width: auto;
+}
+
+#skipButton {
+    white-space: nowrap;
+    font-size: 0.85rem;
+    padding: 0 14px;
+    letter-spacing: 0.05em;
 }
 
 .exit-button {

--- a/css/index.css
+++ b/css/index.css
@@ -311,6 +311,7 @@ p.answer.notselected:hover {
     position: relative;
     overflow: hidden;
     margin: 0rem .2rem;
+    cursor: pointer;
 }
 
 .question-list div::before {
@@ -338,7 +339,12 @@ p.answer.notselected:hover {
     background: #4caf50;
 }
 
-.question-list .correct.wrong::before, 
+.question-list .skipped::before,
+.legend .skipped {
+    background: #9c27b0;
+}
+
+.question-list .correct.wrong::before,
 .legend .correct.wrong {
     background: #ffc107;
 }

--- a/css/index.css
+++ b/css/index.css
@@ -335,6 +335,7 @@ p.answer.notselected:hover {
     font-size: 0.85rem;
     padding: 0 14px;
     letter-spacing: 0.05em;
+    color: white !important;
 }
 
 .exit-button {

--- a/css/index.css
+++ b/css/index.css
@@ -518,3 +518,19 @@ p.answer.notselected:hover {
     border-radius: 50%;
     margin-left: 0.2rem;
 }
+
+.finish-exam-btn {
+    display: block;
+    width: calc(100% - 1.6rem);
+    margin: 0 0.8rem 0.8rem;
+    font-size: 0.8rem;
+    color: #666 !important;
+    border: 1px solid #444;
+    background: transparent;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.finish-exam-btn:hover {
+    color: #f44336 !important;
+    border-color: #f44336;
+}

--- a/css/index.css
+++ b/css/index.css
@@ -67,6 +67,84 @@
     transform: translate(-50%, -50%);
 }
 
+#recentFilesPanel {
+    position: fixed;
+    bottom: 2rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 90%;
+    max-width: 520px;
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 6px;
+    overflow: hidden;
+    z-index: 10;
+}
+
+.recent-files-header {
+    background: #121212;
+    color: #959595;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.4rem 0.8rem;
+    border-bottom: 1px solid #2a2a2a;
+}
+
+.recent-file-item {
+    display: flex;
+    align-items: center;
+    padding: 0.45rem 0.8rem;
+    border-bottom: 1px solid #222;
+    gap: 0.6rem;
+    cursor: pointer;
+    transition: background 0.1s;
+}
+
+.recent-file-item:last-child {
+    border-bottom: none;
+}
+
+.recent-file-item:hover {
+    background: #232323;
+}
+
+.recent-file-name {
+    flex: 1;
+    color: #ddd;
+    font-size: 0.9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.recent-file-item:hover .recent-file-name {
+    color: #1e87f0;
+}
+
+.recent-file-date {
+    color: #555;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    flex-shrink: 0;
+}
+
+.recent-file-delete {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: #444;
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0 0.15rem;
+    flex-shrink: 0;
+    transition: color 0.1s;
+}
+
+.recent-file-delete:hover {
+    color: #f44336;
+}
+
 #confirmTitle {
     position: absolute;
     text-align: center;

--- a/index.html
+++ b/index.html
@@ -104,6 +104,7 @@
                         <span class="circle correct wrong"></span> Corrected
                         <span class="circle skipped"></span> Skipped
                     </div>
+                    <button class="finish-exam-btn uk-button" onclick="confirmFinish()">Ukončit zkoušení</button>
                     <!--
                     <span class="section-title darker">Statistics</span>
                     <div class="stats" id="stats">

--- a/index.html
+++ b/index.html
@@ -81,7 +81,9 @@
 
             <div class="uk-width-1-4@l uk-width-1-5@xl">
                 <div class="sidebar">
-                    <span class="section-title darker">Time</span>
+                    <span class="section-title darker">Time
+                        <button class="pause-toggle-btn" id="pauseButton" onclick="togglePause()" title="Pozastavit/Obnovit">⏸</button>
+                    </span>
                     <span class="timer" id="timer">
                         <!-- JS: Timer --> 00 : 00
                     </span>
@@ -121,8 +123,11 @@
         <h2 id="subtitleText" class="uk-text-center uk-light">
             <!-- JS: subtitle -->
         </h2>
-        <button id="restartButton" class="uk-button uk-button-danger uk-width uk-button-large" type="button"
-            onClick="window.location.reload();">Restart</button>
+        <div id="statsHolder"></div>
+        <div style="text-align:center; margin-top:2rem; padding-bottom:2rem;">
+            <button id="restartButton" class="uk-button uk-button-danger uk-button-large" type="button"
+                onClick="window.location.reload();">Restart</button>
+        </div>
     </div>
 
     <div id="confirmScreen" hidden>

--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
                 </div>
 
                 <button id="checkButton" class="uk-button uk-button-primary uk-width-1-1" type="button" onclick="checkAnswers()">Check</button>
+                <button id="skipButton" class="uk-button uk-button-secondary uk-width-1-1" type="button" onclick="skipQuestion()" style="margin-top:4px;">Skip</button>
                 <hr class="uk-divider-icon" id="qaSplit">
 
                 <zero-md id="md-holder" src=""> <!-- JS: MD -->
@@ -92,6 +93,7 @@
                         <span class="circle correct"></span> Correct
                         <span class="circle wrong"></span> Wrong
                         <span class="circle correct wrong"></span> Corrected
+                        <span class="circle skipped"></span> Skipped
                     </div>
                     <!--
                     <span class="section-title darker">Statistics</span>

--- a/index.html
+++ b/index.html
@@ -61,8 +61,10 @@
                     <!-- JS: Question -->
                 </div>
 
-                <button id="checkButton" class="uk-button uk-button-primary uk-width-1-1" type="button" onclick="checkAnswers()">Check</button>
-                <button id="skipButton" class="uk-button uk-button-secondary uk-width-1-1" type="button" onclick="skipQuestion()" style="margin-top:4px;">Skip</button>
+                <div class="check-skip-row">
+                    <button id="checkButton" class="uk-button uk-button-primary" type="button" onclick="checkAnswers()">Check</button>
+                    <button id="skipButton" class="uk-button uk-button-default" type="button" onclick="skipQuestion()">Skip</button>
+                </div>
                 <hr class="uk-divider-icon" id="qaSplit">
 
                 <zero-md id="md-holder" src=""> <!-- JS: MD -->
@@ -84,7 +86,12 @@
                         <!-- JS: Timer --> 00 : 00
                     </span>
 
-                    <span class="section-title darker">Questions</span>
+                    <span class="section-title darker">Questions
+                        <button class="search-toggle-btn" onclick="toggleSearch()" title="Hledat otázky"><span uk-icon="search"></span></button>
+                    </span>
+                    <div class="question-search-bar" id="questionSearchBar" hidden>
+                        <input type="text" id="questionSearch" class="question-search-input" placeholder="Hledat..." oninput="searchQuestions(this.value)">
+                    </div>
                     <div class="question-list" id="questionList">
                         <!-- JS: Question List -->
                     </div>

--- a/index.html
+++ b/index.html
@@ -41,6 +41,11 @@
             </div>
             <div class="dragInfo line"></div>
         </div>
+
+        <div id="recentFilesPanel" hidden>
+            <div class="recent-files-header">Nedávno otevřené</div>
+            <div id="recentFilesList"></div>
+        </div>
     </div>
 
     <div id="examiner" hidden>

--- a/js/examiner.js
+++ b/js/examiner.js
@@ -114,7 +114,29 @@ class Examiner {
     }
 
     GoToQuestion(id) {
-        return this.questionPool.GetQuestionById(id);
+        // Check active pool first
+        let poolResult = this.questionPool.GetQuestionById(id);
+        if (poolResult) return poolResult;
+
+        // Search in unplayed questions and pull into pool
+        for (let i = this.questionIndex; i < this.questions.length; i++) {
+            if (this.questions[i].id === id) {
+                let q = this.questions[i];
+                this.questions[i] = this.questions[this.questionIndex];
+                this.questions[this.questionIndex] = q;
+                this.questionIndex++;
+                this.questionPool.AddQuestion(q);
+                let newIdx = this.questionPool.questions.length - 1;
+                this.questionPool.currentQuestion = newIdx;
+                this.questionPool.previousQuestion = newIdx;
+                if (this.questionIndex >= this.questions.length) {
+                    this.end = true;
+                }
+                return q;
+            }
+        }
+
+        return null; // Already answered correctly
     }
 
     RemoveCurrentQuestion() {

--- a/js/examiner.js
+++ b/js/examiner.js
@@ -97,7 +97,7 @@ class Examiner {
             qElement.innerText = key + 1;
             qElement.id = 'question-list-item-' + question.id;
             if (question.question && question.question.type === 'text') {
-                qElement.title = question.question.content;
+                setupTooltip(qElement, question.question.content);
             }
             qElement.onclick = function() { goToQuestion(question.id); };
             qListElement.appendChild(qElement);
@@ -111,6 +111,10 @@ class Examiner {
             this.FillQuestionPool();
         }
         return this.questionPool.GetRandomQuestion();
+    }
+
+    GetQuestionDataById(id) {
+        return this.questions.find(q => q.id === id) || null;
     }
 
     GoToQuestion(id) {

--- a/js/examiner.js
+++ b/js/examiner.js
@@ -90,7 +90,9 @@ class Examiner {
         this.end = false;
         this.questionPool = new QuestionPool(poolsize);
 
-        this.startTime = new Date();
+        this.elapsedTime = 0;
+        this.lastResumeTime = Date.now();
+        this.paused = false;
         let qListElement = document.getElementById('questionList');
         questions.forEach((question, key) => {
             let qElement = document.createElement('div');
@@ -145,6 +147,25 @@ class Examiner {
 
     RemoveCurrentQuestion() {
         this.questionPool.RemoveCurrentQuestion();
+    }
+
+    pause() {
+        if (!this.paused) {
+            this.elapsedTime += Date.now() - this.lastResumeTime;
+            this.paused = true;
+        }
+    }
+
+    resume() {
+        if (this.paused) {
+            this.lastResumeTime = Date.now();
+            this.paused = false;
+        }
+    }
+
+    get totalElapsed() {
+        if (this.paused) return this.elapsedTime;
+        return this.elapsedTime + (Date.now() - this.lastResumeTime);
     }
 
     get IsEnd() {

--- a/js/examiner.js
+++ b/js/examiner.js
@@ -70,6 +70,14 @@ class QuestionPool {
         return this.questions[this.currentQuestion];
     }
 
+    GetQuestionById(id) {
+        let idx = this.questions.findIndex(q => q.id === id);
+        if (idx === -1) return null;
+        this.currentQuestion = idx;
+        this.previousQuestion = idx;
+        return this.questions[idx];
+    }
+
     RemoveCurrentQuestion() {
         this.questions.splice(this.currentQuestion, 1);
     }
@@ -88,6 +96,10 @@ class Examiner {
             let qElement = document.createElement('div');
             qElement.innerText = key + 1;
             qElement.id = 'question-list-item-' + question.id;
+            if (question.question && question.question.type === 'text') {
+                qElement.title = question.question.content;
+            }
+            qElement.onclick = function() { goToQuestion(question.id); };
             qListElement.appendChild(qElement);
         });
 
@@ -99,6 +111,10 @@ class Examiner {
             this.FillQuestionPool();
         }
         return this.questionPool.GetRandomQuestion();
+    }
+
+    GoToQuestion(id) {
+        return this.questionPool.GetQuestionById(id);
     }
 
     RemoveCurrentQuestion() {

--- a/js/examiner.js
+++ b/js/examiner.js
@@ -93,6 +93,7 @@ class Examiner {
         this.elapsedTime = 0;
         this.lastResumeTime = Date.now();
         this.paused = false;
+        this.skippedQueue = [];
         let qListElement = document.getElementById('questionList');
         questions.forEach((question, key) => {
             let qElement = document.createElement('div');
@@ -109,10 +110,20 @@ class Examiner {
     }
 
     GetQuestion() {
-        if (!this.questionPool.IsFull) {
+        if (this.questionPool.IsEmpty && this.end && this.skippedQueue.length > 0) {
+            while (!this.questionPool.IsFull && this.skippedQueue.length > 0) {
+                this.questionPool.AddQuestion(this.skippedQueue.shift());
+            }
+        } else if (!this.questionPool.IsFull) {
             this.FillQuestionPool();
         }
         return this.questionPool.GetRandomQuestion();
+    }
+
+    SkipCurrentQuestion() {
+        let q = this.questionPool.questions[this.questionPool.currentQuestion];
+        this.questionPool.RemoveCurrentQuestion();
+        this.skippedQueue.push(q);
     }
 
     GetQuestionDataById(id) {
@@ -135,11 +146,20 @@ class Examiner {
                 let newIdx = this.questionPool.questions.length - 1;
                 this.questionPool.currentQuestion = newIdx;
                 this.questionPool.previousQuestion = newIdx;
-                if (this.questionIndex >= this.questions.length) {
-                    this.end = true;
-                }
+                if (this.questionIndex >= this.questions.length) this.end = true;
                 return q;
             }
+        }
+
+        // Search in skipped queue and pull into pool
+        let sqIdx = this.skippedQueue.findIndex(q => q.id === id);
+        if (sqIdx !== -1) {
+            let q = this.skippedQueue.splice(sqIdx, 1)[0];
+            this.questionPool.AddQuestion(q);
+            let newIdx = this.questionPool.questions.length - 1;
+            this.questionPool.currentQuestion = newIdx;
+            this.questionPool.previousQuestion = newIdx;
+            return q;
         }
 
         return null; // Already answered correctly
@@ -169,11 +189,11 @@ class Examiner {
     }
 
     get IsEnd() {
-        return this.end && this.questionPool.IsEmpty;
+        return this.end && this.questionPool.IsEmpty && this.skippedQueue.length === 0;
     }
 
     get GetQuestionCount() {
-        return this.questions.length - this.questionIndex + this.questionPool.questions.length;
+        return this.questions.length - this.questionIndex + this.questionPool.questions.length + this.skippedQueue.length;
     }
 
     FillQuestionPool() {

--- a/js/index.js
+++ b/js/index.js
@@ -90,6 +90,13 @@ function playGame(dlc) {
  * @brief Shows the next question
  * 
  */
+function syncPauseState() {
+    if (!examiner) return;
+    let paused = examiner.paused;
+    document.getElementById('checkButton').disabled = paused;
+    document.getElementById('skipButton').disabled = paused;
+}
+
 function togglePause() {
     if (!examiner) return;
     if (examiner.paused) {
@@ -101,10 +108,19 @@ function togglePause() {
         document.getElementById('pauseButton').innerText = '▶';
         document.getElementById('timer').classList.add('paused');
     }
+    syncPauseState();
+}
+
+function confirmFinish() {
+    showConfirmscreen("examiner", "Opravdu chcete ukončit zkoušení?<br>Zbývající otázky budou vynechány.", function () {
+        showEndscreen("Ukončeno", "Zkoušení bylo předčasně ukončeno.");
+        showStats(stats, examiner.questions);
+    });
 }
 
 function nextQuestion() {
     showCheckButton();
+    syncPauseState();
 
     question = examiner.GetQuestion();
     questionStartElapsed = examiner.totalElapsed;
@@ -145,6 +161,7 @@ function nextQuestion() {
 function skipQuestion() {
     document.getElementById('question-list-item-' + question.id).classList.add("skipped");
     stats.skippedCount++;
+    examiner.SkipCurrentQuestion();
     nextQuestion();
 }
 
@@ -163,6 +180,7 @@ function goToQuestion(questionId) {
     question = q;
 
     showCheckButton();
+    syncPauseState();
 
     Array.from(document.getElementById('questionList').getElementsByClassName('active')).forEach(x => x.classList.remove('active'));
     document.getElementById("question-list-item-" + question["id"]).classList.add("active");
@@ -218,7 +236,6 @@ function checkAnswers() {
     }
 
     let listItem = document.getElementById('question-list-item-' + question.id);
-    let wasSkipped = listItem.classList.contains("skipped");
     listItem.classList.remove("skipped");
 
     let questionTime = examiner.totalElapsed - questionStartElapsed;

--- a/js/index.js
+++ b/js/index.js
@@ -173,12 +173,14 @@ function checkAnswers() {
         }
     }
 
+    let listItem = document.getElementById('question-list-item-' + question.id);
+    listItem.classList.remove("skipped");
+
     if (allcorrect) {
         examiner.RemoveCurrentQuestion();
-        document.getElementById('question-list-item-' + question.id).classList.add("correct");
+        listItem.classList.add("correct");
         console.log("Removed Question ID: " + question["id"]);
         if (examiner.IsEnd) {
-            //alert("Congratulations! You have answered all questions correctly!");
             document.getElementById("checkButton").innerHTML = "LET'S GOO";
             document.getElementById("checkButton").onclick = function () {
                 showEndscreen("Congratulations!", "You have answered all questions correctly!");
@@ -188,7 +190,7 @@ function checkAnswers() {
         console.log("All correct");
     }
     else {
-        document.getElementById('question-list-item-' + question.id).classList.add("wrong");
+        listItem.classList.add("wrong");
         console.log("Not all correct");
     }
 

--- a/js/index.js
+++ b/js/index.js
@@ -55,6 +55,7 @@ function loadQuestions(contents) {
 
 let examiner;
 let question;
+let reviewMode = false;
 
 /**
  * @brief creates the examiner and starts the exam
@@ -124,11 +125,16 @@ function skipQuestion() {
 }
 
 /**
- * @brief Navigates to a specific question by ID (only if it's in the active pool)
+ * @brief Navigates to a specific question by ID (pool or already answered)
  */
 function goToQuestion(questionId) {
     let q = examiner.GoToQuestion(questionId);
-    if (!q) return;
+    reviewMode = !q;
+
+    if (reviewMode) {
+        q = examiner.GetQuestionDataById(questionId);
+        if (!q) return;
+    }
 
     question = q;
 
@@ -139,6 +145,18 @@ function goToQuestion(questionId) {
 
     cleanUpHolders();
     interpretQuestion(question);
+
+    if (reviewMode) {
+        hideSkipButton();
+        let checkBtn = document.getElementById("checkButton");
+        checkBtn.innerHTML = "Continue";
+        checkBtn.onclick = exitReviewMode;
+    }
+}
+
+function exitReviewMode() {
+    reviewMode = false;
+    nextQuestion();
 }
 
 /**

--- a/js/index.js
+++ b/js/index.js
@@ -56,6 +56,15 @@ function loadQuestions(contents) {
 let examiner;
 let question;
 let reviewMode = false;
+let questionStartElapsed = 0;
+let stats = {
+    correctAttempts: 0,
+    wrongAttempts: 0,
+    correctedCount: 0,
+    skippedCount: 0,
+    answerTimes: [],
+    questionWrongCounts: {},
+};
 
 /**
  * @brief creates the examiner and starts the exam
@@ -81,10 +90,24 @@ function playGame(dlc) {
  * @brief Shows the next question
  * 
  */
+function togglePause() {
+    if (!examiner) return;
+    if (examiner.paused) {
+        examiner.resume();
+        document.getElementById('pauseButton').innerText = '⏸';
+        document.getElementById('timer').classList.remove('paused');
+    } else {
+        examiner.pause();
+        document.getElementById('pauseButton').innerText = '▶';
+        document.getElementById('timer').classList.add('paused');
+    }
+}
+
 function nextQuestion() {
     showCheckButton();
 
     question = examiner.GetQuestion();
+    questionStartElapsed = examiner.totalElapsed;
 
     console.log(question);
     console.log("Loaded Question ID: " + question["id"]);
@@ -121,6 +144,7 @@ function nextQuestion() {
  */
 function skipQuestion() {
     document.getElementById('question-list-item-' + question.id).classList.add("skipped");
+    stats.skippedCount++;
     nextQuestion();
 }
 
@@ -151,6 +175,8 @@ function goToQuestion(questionId) {
         let checkBtn = document.getElementById("checkButton");
         checkBtn.innerHTML = "Continue";
         checkBtn.onclick = exitReviewMode;
+    } else {
+        questionStartElapsed = examiner.totalElapsed;
     }
 }
 
@@ -192,9 +218,15 @@ function checkAnswers() {
     }
 
     let listItem = document.getElementById('question-list-item-' + question.id);
+    let wasSkipped = listItem.classList.contains("skipped");
     listItem.classList.remove("skipped");
 
+    let questionTime = examiner.totalElapsed - questionStartElapsed;
+
     if (allcorrect) {
+        stats.correctAttempts++;
+        stats.answerTimes.push(questionTime);
+        if ((stats.questionWrongCounts[question.id] || 0) > 0) stats.correctedCount++;
         examiner.RemoveCurrentQuestion();
         listItem.classList.add("correct");
         console.log("Removed Question ID: " + question["id"]);
@@ -202,12 +234,15 @@ function checkAnswers() {
             document.getElementById("checkButton").innerHTML = "LET'S GOO";
             document.getElementById("checkButton").onclick = function () {
                 showEndscreen("Congratulations!", "You have answered all questions correctly!");
-            }
+                showStats(stats, examiner.questions);
+            };
             return;
         }
         console.log("All correct");
     }
     else {
+        stats.wrongAttempts++;
+        stats.questionWrongCounts[question.id] = (stats.questionWrongCounts[question.id] || 0) + 1;
         listItem.classList.add("wrong");
         console.log("Not all correct");
     }
@@ -250,8 +285,9 @@ document.getElementById('uploadButton').addEventListener('dragleave', () => {
 
 // Timer
 setInterval(() => {
-    if (examiner != null && examiner.startTime != undefined) {
-        let seconds = Math.ceil((Date.now() - examiner.startTime) / 1000);
+    if (examiner != null) {
+        let ms = examiner.totalElapsed;
+        let seconds = Math.ceil(ms / 1000);
         let minutes = Math.floor(seconds / 60);
         let hours = Math.floor(minutes / 60);
         document.getElementById('timer').innerText = (hours > 0 ? String(hours).padStart(2, '0') + ' : ' : '') + String(minutes % 60).padStart(2, '0') + " : " + String(seconds % 60).padStart(2, '0');

--- a/js/index.js
+++ b/js/index.js
@@ -19,7 +19,7 @@ function readSingleFile(e) {
     reader.onload = function (e) {
         var contents = e.target.result;
         console.log("Loading file " + file.name);
-        loadQuestions(contents);
+        loadQuestions(contents, file.name);
     };
     reader.readAsText(file);
 }
@@ -32,7 +32,7 @@ function readSingleFile(e) {
  * @param {*} contents  .dlc file contents
  * @returns 
  */
-function loadQuestions(contents) {
+function loadQuestions(contents, fileName) {
     var questions;
     try {
         questions = JSON.parse(contents);
@@ -45,10 +45,12 @@ function loadQuestions(contents) {
     if (!VerifyDlc(questions))
         return;
 
+    saveToRecent(fileName || questions["name"], contents);
+
     console.log("Loaded " + questions["name"] + " dlc");
 
     var uploadButton = document.getElementById("uploadButton");
-    uploadButton.parentNode.removeChild(uploadButton);
+    if (uploadButton) uploadButton.parentNode.removeChild(uploadButton);
 
     playGame(questions);
 }
@@ -279,10 +281,12 @@ document.getElementById('file-input')
 
 // Drag and drop area
 document.addEventListener('dragenter', () => {
-    document.getElementById('uploadButton').classList.add('onDrag');
-})
-document.getElementById('uploadButton').addEventListener('dragleave', () => {
-    document.getElementById('uploadButton').classList.remove('onDrag');
+    let btn = document.getElementById('uploadButton');
+    if (btn) btn.classList.add('onDrag');
+});
+let _uploadBtn = document.getElementById('uploadButton');
+if (_uploadBtn) _uploadBtn.addEventListener('dragleave', () => {
+    _uploadBtn.classList.remove('onDrag');
 });
 
 // Load file from url
@@ -299,6 +303,91 @@ document.getElementById('uploadButton').addEventListener('dragleave', () => {
     // if (confirm("You are about to load a DLC file from a url.\nAre you sure you trust the source?"))
     //     loadFromURL(fileUrl);
 })();
+
+// Recent files
+const RECENT_FILES_KEY = 'examiner_recent_files';
+const RECENT_FILES_MAX = 8;
+
+function getRecentFiles() {
+    try {
+        return JSON.parse(localStorage.getItem(RECENT_FILES_KEY)) || [];
+    } catch {
+        return [];
+    }
+}
+
+function saveToRecent(name, content) {
+    try {
+        let recent = getRecentFiles();
+        recent = recent.filter(f => f.name !== name);
+        recent.unshift({ name, content, timestamp: Date.now() });
+        recent = recent.slice(0, RECENT_FILES_MAX);
+        localStorage.setItem(RECENT_FILES_KEY, JSON.stringify(recent));
+    } catch (e) {
+        console.warn('Could not save to recent files:', e);
+    }
+}
+
+function deleteFromRecent(index) {
+    let recent = getRecentFiles();
+    recent.splice(index, 1);
+    try {
+        localStorage.setItem(RECENT_FILES_KEY, JSON.stringify(recent));
+    } catch (e) {}
+    renderRecentFiles();
+}
+
+function loadFromRecent(index) {
+    let recent = getRecentFiles();
+    if (!recent[index]) return;
+    loadQuestions(recent[index].content, recent[index].name);
+}
+
+function renderRecentFiles() {
+    let panel = document.getElementById('recentFilesPanel');
+    if (!panel) return;
+    let recent = getRecentFiles();
+    if (recent.length === 0) {
+        panel.hidden = true;
+        return;
+    }
+    panel.hidden = false;
+    let list = document.getElementById('recentFilesList');
+    list.innerHTML = '';
+    recent.forEach(function (file, index) {
+        let date = new Date(file.timestamp).toLocaleString('cs-CZ', {
+            day: '2-digit', month: '2-digit', year: 'numeric',
+            hour: '2-digit', minute: '2-digit'
+        });
+        let item = document.createElement('div');
+        item.className = 'recent-file-item';
+        item.onclick = function () { loadFromRecent(index); };
+
+        let nameSpan = document.createElement('span');
+        nameSpan.className = 'recent-file-name';
+        nameSpan.textContent = file.name;
+
+        let dateSpan = document.createElement('span');
+        dateSpan.className = 'recent-file-date';
+        dateSpan.textContent = date;
+
+        let delBtn = document.createElement('button');
+        delBtn.className = 'recent-file-delete';
+        delBtn.innerHTML = '&times;';
+        delBtn.title = 'Odstranit ze seznamu';
+        delBtn.onclick = function (e) {
+            e.stopPropagation();
+            deleteFromRecent(index);
+        };
+
+        item.appendChild(nameSpan);
+        item.appendChild(dateSpan);
+        item.appendChild(delBtn);
+        list.appendChild(item);
+    });
+}
+
+renderRecentFiles();
 
 // Timer
 setInterval(() => {

--- a/js/index.js
+++ b/js/index.js
@@ -116,10 +116,37 @@ function nextQuestion() {
 
 
 /**
+ * @brief Skips the current question and marks it with a purple flag
+ */
+function skipQuestion() {
+    document.getElementById('question-list-item-' + question.id).classList.add("skipped");
+    nextQuestion();
+}
+
+/**
+ * @brief Navigates to a specific question by ID (only if it's in the active pool)
+ */
+function goToQuestion(questionId) {
+    let q = examiner.GoToQuestion(questionId);
+    if (!q) return;
+
+    question = q;
+
+    showCheckButton();
+
+    Array.from(document.getElementById('questionList').getElementsByClassName('active')).forEach(x => x.classList.remove('active'));
+    document.getElementById("question-list-item-" + question["id"]).classList.add("active");
+
+    cleanUpHolders();
+    interpretQuestion(question);
+}
+
+/**
  * @brief Checks the answers and shows the correct answer
- * 
+ *
  */
 function checkAnswers() {
+    hideSkipButton();
     let allcorrect = true;
     for (let i = 0; i < question.answers.length; i++) {
         let answer = question.answers[i];

--- a/js/interpret.js
+++ b/js/interpret.js
@@ -143,6 +143,10 @@ function select(id) {
 
 
     const correctButtonFn = function () {
+        let questionTime = examiner.totalElapsed - questionStartElapsed;
+        stats.correctAttempts++;
+        stats.answerTimes.push(questionTime);
+        if ((stats.questionWrongCounts[question.id] || 0) > 0) stats.correctedCount++;
         examiner.RemoveCurrentQuestion();
         let listItem = document.getElementById('question-list-item-' + question.id);
         listItem.classList.remove("skipped");
@@ -150,6 +154,7 @@ function select(id) {
         console.log("Removed Question ID: " + question["id"]);
         if (examiner.IsEnd) {
             showEndscreen("Congratulations!", "You have answered all questions correctly!");
+            showStats(stats, examiner.questions);
             return;
         }
         console.log("Correct");
@@ -158,6 +163,8 @@ function select(id) {
     answersHolder.appendChild(createCorrectBtn(correctButtonFn));
 
     const incorrectButtonFn = function () {
+        stats.wrongAttempts++;
+        stats.questionWrongCounts[question.id] = (stats.questionWrongCounts[question.id] || 0) + 1;
         let listItem = document.getElementById('question-list-item-' + question.id);
         listItem.classList.remove("skipped");
         listItem.classList.add("wrong");

--- a/js/interpret.js
+++ b/js/interpret.js
@@ -101,6 +101,7 @@ function addImageToHolder(holder, src, isAnswer = false, id = -1){
 
 
 function select(id) {
+    if (examiner && examiner.paused) return;
     console.log("Selected " + id);
     if (question["answers"][id]["selected"]) {
         question["answers"][id]["selected"] = false;

--- a/js/interpret.js
+++ b/js/interpret.js
@@ -144,7 +144,9 @@ function select(id) {
 
     const correctButtonFn = function () {
         examiner.RemoveCurrentQuestion();
-        document.getElementById('question-list-item-' + question.id).classList.add("correct");
+        let listItem = document.getElementById('question-list-item-' + question.id);
+        listItem.classList.remove("skipped");
+        listItem.classList.add("correct");
         console.log("Removed Question ID: " + question["id"]);
         if (examiner.IsEnd) {
             showEndscreen("Congratulations!", "You have answered all questions correctly!");
@@ -156,7 +158,9 @@ function select(id) {
     answersHolder.appendChild(createCorrectBtn(correctButtonFn));
 
     const incorrectButtonFn = function () {
-        document.getElementById('question-list-item-' + question.id).classList.add("wrong");
+        let listItem = document.getElementById('question-list-item-' + question.id);
+        listItem.classList.remove("skipped");
+        listItem.classList.add("wrong");
         console.log("incorrect");
         nextQuestion();
     };

--- a/js/utils.js
+++ b/js/utils.js
@@ -106,6 +106,31 @@ function loadFromURL(url) {
 }
 
 
+function toggleSearch() {
+    let bar = document.getElementById('questionSearchBar');
+    bar.hidden = !bar.hidden;
+    if (!bar.hidden) {
+        document.getElementById('questionSearch').focus();
+    } else {
+        document.getElementById('questionSearch').value = '';
+        searchQuestions('');
+    }
+}
+
+function searchQuestions(value) {
+    let items = document.getElementById('questionList').children;
+    let query = value.trim().toLowerCase();
+    for (let item of items) {
+        if (!query) {
+            item.style.display = '';
+        } else {
+            let title = (item.title || '').toLowerCase();
+            let number = item.innerText.trim();
+            item.style.display = (title.includes(query) || number === query) ? '' : 'none';
+        }
+    }
+}
+
 function createCorrectBtn(fn) {
     let correctButton = document.createElement("button");
     correctButton.innerHTML = "<span uk-icon='icon: check; ratio: 5.5'></span>";

--- a/js/utils.js
+++ b/js/utils.js
@@ -59,10 +59,16 @@ function showExaminer(dlcname) {
 
 function hideCheckButton() {
     document.getElementById("checkButton").hidden = true;
+    document.getElementById("skipButton").hidden = true;
 }
 
 function showCheckButton() {
     document.getElementById("checkButton").hidden = false;
+    document.getElementById("skipButton").hidden = false;
+}
+
+function hideSkipButton() {
+    document.getElementById("skipButton").hidden = true;
 }
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -106,6 +106,37 @@ function loadFromURL(url) {
 }
 
 
+let _tooltip = null;
+function _getTooltip() {
+    if (!_tooltip) {
+        _tooltip = document.createElement('div');
+        _tooltip.style.cssText = 'position:fixed;background:#1a1a1a;color:white;padding:5px 10px;border-radius:4px;font-size:0.85rem;max-width:300px;z-index:9999;pointer-events:none;display:none;word-wrap:break-word;border:1px solid #444;line-height:1.4;';
+        document.body.appendChild(_tooltip);
+    }
+    return _tooltip;
+}
+
+function setupTooltip(element, text) {
+    element.addEventListener('mouseenter', function () {
+        let t = _getTooltip();
+        t.innerText = text;
+        t.style.display = 'block';
+    });
+    element.addEventListener('mousemove', function (e) {
+        let t = _getTooltip();
+        let x = e.clientX + 15;
+        let y = e.clientY + 10;
+        if (x + 300 > window.innerWidth) x = e.clientX - 310;
+        if (y + 60 > window.innerHeight) y = e.clientY - 50;
+        t.style.left = x + 'px';
+        t.style.top = y + 'px';
+    });
+    element.addEventListener('mouseleave', function () {
+        _getTooltip().style.display = 'none';
+    });
+    element.dataset.tooltipText = text;
+}
+
 function toggleSearch() {
     let bar = document.getElementById('questionSearchBar');
     bar.hidden = !bar.hidden;
@@ -124,7 +155,7 @@ function searchQuestions(value) {
         if (!query) {
             item.style.display = '';
         } else {
-            let title = (item.title || '').toLowerCase();
+            let title = (item.dataset.tooltipText || '').toLowerCase();
             let number = item.innerText.trim();
             item.style.display = (title.includes(query) || number === query) ? '' : 'none';
         }

--- a/js/utils.js
+++ b/js/utils.js
@@ -124,10 +124,12 @@ function setupTooltip(element, text) {
     });
     element.addEventListener('mousemove', function (e) {
         let t = _getTooltip();
-        let x = e.clientX + 15;
-        let y = e.clientY + 10;
-        if (x + 300 > window.innerWidth) x = e.clientX - 310;
-        if (y + 60 > window.innerHeight) y = e.clientY - 50;
+        let tw = t.offsetWidth || 300;
+        let th = t.offsetHeight || 40;
+        let x = e.clientX + 14;
+        let y = e.clientY + 12;
+        if (x + tw > window.innerWidth) x = e.clientX - tw - 10;
+        if (y + th > window.innerHeight) y = e.clientY - th - 8;
         t.style.left = x + 'px';
         t.style.top = y + 'px';
     });
@@ -160,6 +162,70 @@ function searchQuestions(value) {
             item.style.display = (title.includes(query) || number === query) ? '' : 'none';
         }
     }
+}
+
+function showStats(statsData, questions) {
+    let holder = document.getElementById('statsHolder');
+    if (!holder || !statsData) return;
+
+    function fmtTime(ms) {
+        if (!ms || ms < 0) return '0:00';
+        let s = Math.floor(ms / 1000);
+        let m = Math.floor(s / 60);
+        return m + ':' + String(s % 60).padStart(2, '0');
+    }
+
+    let times = statsData.answerTimes;
+    let avgMs = times.length ? times.reduce((a, b) => a + b, 0) / times.length : 0;
+    let maxMs = times.length ? Math.max(...times) : 0;
+
+    let html = `<div class="stats-grid">
+        <div class="stats-card correct">
+            <span class="stats-card-value">${statsData.correctAttempts}</span>
+            <span class="stats-card-label">Správně zodpovězeno</span>
+        </div>
+        <div class="stats-card wrong">
+            <span class="stats-card-value">${statsData.wrongAttempts}</span>
+            <span class="stats-card-label">Špatných pokusů</span>
+        </div>
+        <div class="stats-card corrected">
+            <span class="stats-card-value">${statsData.correctedCount}</span>
+            <span class="stats-card-label">Opraveno</span>
+        </div>
+        <div class="stats-card skipped">
+            <span class="stats-card-value">${statsData.skippedCount}</span>
+            <span class="stats-card-label">Přeskočeno</span>
+        </div>
+        <div class="stats-card">
+            <span class="stats-card-value">${fmtTime(avgMs)}</span>
+            <span class="stats-card-label">Průměrný čas odpovědi</span>
+        </div>
+        <div class="stats-card">
+            <span class="stats-card-value">${fmtTime(maxMs)}</span>
+            <span class="stats-card-label">Nejdelší čas odpovědi</span>
+        </div>
+    </div>`;
+
+    let wrongEntries = Object.entries(statsData.questionWrongCounts)
+        .filter(([, c]) => c > 0)
+        .sort((a, b) => b[1] - a[1]);
+
+    if (wrongEntries.length > 0) {
+        html += `<p class="stats-section-title">Chybně zodpovězené otázky</p>
+        <table class="stats-table">
+            <thead><tr><th>Otázka</th><th style="text-align:center;">Špatných pokusů</th></tr></thead>
+            <tbody>`;
+        for (let [id, count] of wrongEntries) {
+            let q = questions.find(q => String(q.id) === String(id));
+            let text = (q && q.question && q.question.type === 'text')
+                ? (q.question.content.length > 90 ? q.question.content.substring(0, 90) + '…' : q.question.content)
+                : `Otázka ID ${id}`;
+            html += `<tr><td>${text}</td><td>${count}</td></tr>`;
+        }
+        html += `</tbody></table>`;
+    }
+
+    holder.innerHTML = html;
 }
 
 function createCorrectBtn(fn) {


### PR DESCRIPTION
## Changelog

### Question Navigation
- Questions in the sidebar list are now clickable — clicking a number navigates directly to that question
- Hovering over a question number shows its title immediately (custom tooltip, no browser delay)
- A magnifying glass icon next to the **Questions** header opens a search bar to filter questions by text or number
- Already-correctly-answered questions can be revisited in **review mode** (read-only, no skip — only a *Continue* button)

### Skip
- Added a **Skip** button next to *Check*; skipped questions are marked with a **purple flag**
- Skipped questions are deferred to the end of the queue — all remaining unskipped questions are shown first
- Answering a previously skipped question correctly clears the purple flag and marks it **green**; if it was also answered wrong before skipping, it is marked **amber** (corrected)

### Timer
- Added a **pause / resume** button (⏸ / ▶) in the *Time* sidebar header
- While paused, the timer text greys out and all interaction is blocked — answers cannot be selected, *Check* and *Skip* are disabled
- Paused time is excluded from answer time statistics

### Statistics
Shown on the end screen after completing or finishing the exam early:
- **Correct answers** — number of questions completed correctly
- **Wrong attempts** — total number of failed *Check* presses
- **Corrected** — questions that were answered wrong at least once before being corrected
- **Skipped** — total number of explicit skip actions
- **Average answer time** and **longest answer time** per question (pause time excluded)
- A table of questions that were answered incorrectly at least once, sorted by wrong-attempt count

### Recent Files
- On the start screen, a panel at the bottom lists the **last 8 opened `.dlc` files** (name + date/time), persisted in `localStorage`
- Clicking an entry reloads the file without re-uploading
- Each entry has a **×** delete button to remove invalid or unwanted records
- The panel is hidden automatically when an exam starts

### Finish Early
- A **Ukončit zkoušení** (*Finish exam*) button at the bottom of the sidebar ends the exam early after a confirmation dialog
- Full statistics are shown on the resulting end screen