### PR TITLE
Add shown/hidden count per group and global show/hide-all toggle

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1733,6 +1733,16 @@ p.answer.dismissed {
     color: white;
 }
 
+.wheel-group-count {
+    flex-shrink: 0;
+    margin-right: 0.4rem;
+    color: #888;
+    font-size: 0.7rem;
+    font-weight: bold;
+    letter-spacing: 0;
+    font-variant-numeric: tabular-nums;
+}
+
 .wheel-group-header.collapsed {
     margin-bottom: 0.5rem;
 }

--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
                     <span class="timer wheel-timer" id="wheelTimer" hidden>00 : 00</span>
 
                     <span class="section-title darker">Questions
-                        <button class="wheel-showall-btn" id="wheelShowAllBtn" title="Show all hidden questions">⟳</button>
+                        <button class="wheel-showall-btn" id="wheelShowAllBtn" title="Hide all questions">⦸</button>
                         <button class="wheel-search-btn" id="wheelSearchBtn" title="Search questions"><span uk-icon="search"></span></button>
                         <button class="wheel-shuffle-header-btn" id="wheelShuffleBtn" title="Randomize wheel section order">⇄</button>
                     </span>

--- a/js/wheel.js
+++ b/js/wheel.js
@@ -488,7 +488,7 @@ class QuestionsWheel {
 
         let showAllBtn = document.getElementById('wheelShowAllBtn');
         if (showAllBtn) {
-            showAllBtn.onclick = () => this.showAllQuestions();
+            showAllBtn.onclick = () => this.toggleAllQuestions();
         }
 
         this.render();
@@ -504,13 +504,26 @@ class QuestionsWheel {
         playSound('wheel-shuffle');
     }
 
-    showAllQuestions() {
+    toggleAllQuestions() {
         if (this.spinning) return;
-        if (this.hidden.size === 0) return;
-        this.hidden.clear();
+        if (this.questions.length === 0) return;
+        let anyVisible = this.questions.some(q => !this.hidden.has(q.id));
+        if (anyVisible) {
+            this.questions.forEach(q => this.hidden.add(q.id));
+        } else {
+            this.hidden.clear();
+        }
         this.resetSpinner();
         this.render();
-        playSound('select');
+        playSound(anyVisible ? 'deselect' : 'select');
+    }
+
+    updateShowAllBtn() {
+        let btn = document.getElementById('wheelShowAllBtn');
+        if (!btn) return;
+        let anyVisible = this.questions.some(q => !this.hidden.has(q.id));
+        btn.textContent = anyVisible ? '⦸' : '⟳';
+        btn.title = anyVisible ? 'Hide all questions' : 'Show all questions';
     }
 
     applySize() {
@@ -594,6 +607,7 @@ class QuestionsWheel {
         this.renderWheel();
         this.renderSidebar();
         this.updateSpinButton();
+        this.updateShowAllBtn();
         this.persistState();
     }
 
@@ -860,6 +874,14 @@ class QuestionsWheel {
                     this.render();
                     playSound(allHidden ? 'select' : 'deselect');
                 };
+
+                let shownCount = items.reduce((n, q) => n + (this.hidden.has(q.id) ? 0 : 1), 0);
+                let count = document.createElement('span');
+                count.className = 'wheel-group-count';
+                count.textContent = shownCount + '/' + items.length;
+                count.title = shownCount + ' shown, ' + (items.length - shownCount) + ' hidden';
+                header.appendChild(count);
+
                 header.appendChild(toggleBtn);
                 list.appendChild(header);
 


### PR DESCRIPTION
Show a "shown/total" tracker in each group header (left of the eye icon) and make the overall questions button toggle between hiding all and showing all instead of only showing hidden ones.