### PR TITLE
feat: timer in modal side panel, member avg rating, stats table

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -1786,7 +1786,7 @@ p.answer.dismissed {
 #wheelModalMembersBtn[hidden] { display: none; }
 
 #wheelMembersPanel {
-    width: 250px;
+    width: 100%;
     flex-shrink: 0;
     max-height: 90vh;
     overflow-y: auto;
@@ -2398,7 +2398,6 @@ p.answer.dismissed {
         padding: 0.7rem 1rem 1rem;
     }
     #wheelMembersPanel {
-        width: 100%;
         max-height: 40vh;
     }
 }
@@ -2589,4 +2588,207 @@ p.answer.dismissed {
     font-size: 0.72rem;
     font-weight: bold;
     white-space: nowrap;
+}
+
+/* ── Modal side panel (timer + members, stacked vertically) ─────────────────── */
+
+#wheelModalSide {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    width: 250px;
+    flex-shrink: 0;
+    align-items: stretch;
+}
+
+#wheelModalSide[hidden] { display: none; }
+
+/* Timer box in modal side panel */
+.wheel-modal-timer-box {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 0.7rem 1rem 0.9rem;
+    flex-shrink: 0;
+}
+
+.wheel-modal-timer-box[hidden] { display: none; }
+
+.wheel-modal-timer-label {
+    color: #8d8d8d;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 0.2rem;
+}
+
+.wheel-modal-timer {
+    font-size: 2rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.05em;
+    color: #fff;
+}
+
+/* Member average rating badge shown in each member row */
+.wheel-member-avg-rating {
+    flex-shrink: 0;
+    font-size: 0.72rem;
+    font-weight: bold;
+    color: #ffb300;
+    white-space: nowrap;
+    min-width: 2.6rem;
+    text-align: right;
+    cursor: default;
+}
+
+/* Stats button in the Questions section header */
+.wheel-stats-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 0.95rem;
+    padding: 0 0.2rem;
+    line-height: 1;
+    opacity: 0.7;
+    transition: opacity 0.12s;
+}
+
+.wheel-stats-btn:hover { opacity: 1; }
+
+/* ── Rating statistics modal ────────────────────────────────────────────────── */
+
+#wheelStatsModal {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: rgba(0, 0, 0, 0.8);
+    z-index: 1200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+#wheelStatsModal[hidden] { display: none; }
+
+#wheelStatsContent {
+    background: #1a1a1a;
+    border: 1px solid #333;
+    border-radius: 8px;
+    max-width: 620px;
+    width: 100%;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.wheel-stats-header {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.85rem 1rem;
+    border-bottom: 1px solid #2e2e2e;
+    flex-shrink: 0;
+}
+
+.wheel-stats-title {
+    font-size: 1rem;
+    font-weight: bold;
+    color: #eee;
+    flex-shrink: 0;
+}
+
+.wheel-stats-select {
+    flex: 1;
+    background: #242424;
+    border: 1px solid #444;
+    color: #ddd;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    padding: 0.25rem 0.5rem;
+    font-family: inherit;
+    cursor: pointer;
+    min-width: 0;
+}
+
+.wheel-stats-select:focus { outline: none; border-color: #1e87f0; }
+
+.wheel-stats-body {
+    padding: 0.6rem 1rem 1rem;
+    overflow-y: auto;
+}
+
+.wheel-stats-summary {
+    color: #8899aa;
+    font-size: 0.78rem;
+    margin: 0.2rem 0 0.8rem;
+}
+
+.wheel-stats-empty {
+    color: #888;
+    font-size: 0.9rem;
+    padding: 0.8rem 0;
+}
+
+.wheel-stats-group {
+    margin-bottom: 0.9rem;
+}
+
+.wheel-stats-group-head {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid #2a2a2a;
+    margin-bottom: 0.35rem;
+}
+
+.wheel-stats-group-name {
+    flex: 1;
+    font-weight: bold;
+    color: #ddd;
+    font-size: 0.9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.wheel-stats-group-avg {
+    flex-shrink: 0;
+    color: #ffb300;
+    font-size: 0.8rem;
+    font-weight: bold;
+}
+
+.wheel-stats-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.22rem 0 0.22rem 1.15rem;
+    color: #cfcfcf;
+    font-size: 0.84rem;
+}
+
+.wheel-stats-q {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.wheel-stats-stars {
+    flex-shrink: 0;
+    color: #ffb300;
+    font-size: 0.78rem;
+    font-weight: bold;
+}
+
+@media (max-width: 600px) {
+    #wheelModalSide {
+        width: 100%;
+        flex-direction: column;
+    }
 }

--- a/css/index.css
+++ b/css/index.css
@@ -2720,6 +2720,31 @@ p.answer.dismissed {
     color: #959595;
 }
 
+.wheel-global-inq {
+    display: flex;
+    justify-content: center;
+    align-items: baseline;
+    gap: 0.4rem;
+    margin-top: -0.2rem;
+    padding-bottom: 0.2rem;
+    color: #888;
+    font-size: 0.78rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.wheel-global-inq[hidden] { display: none; }
+
+.wheel-global-inq-label {
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: 0.68rem;
+    color: #6f6f6f;
+}
+
+.wheel-global-inq-value {
+    color: #c0c0c0;
+}
+
 /* Stats button in the Questions section header */
 .wheel-stats-btn {
     background: none;

--- a/css/index.css
+++ b/css/index.css
@@ -2720,18 +2720,6 @@ p.answer.dismissed {
     color: #959595;
 }
 
-/* Member average rating badge shown in each member row */
-.wheel-member-avg-rating {
-    flex-shrink: 0;
-    font-size: 0.72rem;
-    font-weight: bold;
-    color: #ffb300;
-    white-space: nowrap;
-    min-width: 2.6rem;
-    text-align: right;
-    cursor: default;
-}
-
 /* Stats button in the Questions section header */
 .wheel-stats-btn {
     background: none;

--- a/css/index.css
+++ b/css/index.css
@@ -2056,6 +2056,35 @@ p.answer.dismissed {
     font-size: 0.75rem;
 }
 
+.wheel-member-detail-group-avg {
+    flex-shrink: 0;
+    color: #ffb300;
+    font-size: 0.78rem;
+    font-weight: bold;
+    margin-right: 0.15rem;
+}
+
+.wheel-member-detail-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 0.5rem;
+    padding: 0.55rem 0.4rem 0.3rem;
+    border-top: 1px solid #2a2a2a;
+}
+
+.wheel-member-detail-footer-label {
+    color: #aaa;
+    font-size: 0.85rem;
+    font-weight: bold;
+}
+
+.wheel-member-detail-footer-avg {
+    color: #ffb300;
+    font-size: 1rem;
+    font-weight: bold;
+}
+
 .wheel-member-detail-row {
     display: flex;
     align-items: center;
@@ -2611,7 +2640,7 @@ p.answer.dismissed {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 0.7rem 1rem 0.9rem;
+    padding: 0.7rem 1rem 0.8rem;
     flex-shrink: 0;
 }
 
@@ -2630,6 +2659,65 @@ p.answer.dismissed {
     font-variant-numeric: tabular-nums;
     letter-spacing: 0.05em;
     color: #fff;
+}
+
+.wheel-modal-timer-controls {
+    display: flex;
+    gap: 0.6rem;
+    margin-top: 0.4rem;
+}
+
+.wheel-modal-timer-btn {
+    background: none;
+    border: 1px solid #3a3a3a;
+    color: #bbb;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    line-height: 1;
+    padding: 0.15rem 0.55rem;
+    transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+
+.wheel-modal-timer-btn:hover {
+    color: #fff;
+    border-color: #555;
+    background: #242424;
+}
+
+/* Global timer box at top of the sidebar */
+.wheel-global-timer-box {
+    position: relative;
+    margin-bottom: 0.4rem;
+}
+
+.wheel-global-timer-box[hidden] { display: none; }
+
+.wheel-global-timer-title {
+    position: relative;
+    padding-right: 2.4rem;
+}
+
+.wheel-global-pause-btn {
+    /* Reuse .pause-toggle-btn positioning but scoped here for clarity. */
+    position: absolute;
+    right: 0.3rem;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.wheel-global-timer {
+    display: block;
+    text-align: center;
+    color: white;
+    font-size: 2.4rem;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.05em;
+    padding: 0.3rem 0;
+}
+
+.wheel-global-timer.paused {
+    color: #959595;
 }
 
 /* Member average rating badge shown in each member row */

--- a/index.html
+++ b/index.html
@@ -222,9 +222,13 @@
                             <span class="wheel-config-label">Center on screen</span>
                             <span class="sound-switch" id="wheelCenteredSwitch"></span>
                         </label>
-                        <label class="wheel-config-row wheel-config-toggle-row" id="wheelTimerRow" data-tooltip="Run a timer while a question is open">
+                        <label class="wheel-config-row wheel-config-toggle-row" id="wheelTimerRow" data-tooltip="Show a global timer and a per-question timer">
                             <span class="wheel-config-label">Timer</span>
                             <span class="sound-switch" id="wheelTimerSwitch"></span>
+                        </label>
+                        <label class="wheel-config-row wheel-config-toggle-row" id="wheelTimerContinuousRow" data-tooltip="On: global timer ticks continuously. Off: only counts while a question is open.">
+                            <span class="wheel-config-label">Count always</span>
+                            <span class="sound-switch" id="wheelTimerContinuousSwitch"></span>
                         </label>
                         <label class="wheel-config-row wheel-config-toggle-row" id="wheelMembersRow" data-tooltip="Track members answering each question — edit the roster with the people icon">
                             <span class="wheel-config-label">Members</span>
@@ -276,6 +280,10 @@
                             <button class="pause-toggle-btn wheel-global-pause-btn" id="wheelGlobalPauseBtn" type="button" title="Pause/Continue total timer">⏸</button>
                         </span>
                         <span class="timer wheel-global-timer" id="wheelGlobalTimer">00 : 00</span>
+                        <span class="wheel-global-inq" id="wheelGlobalInQuestion" hidden>
+                            <span class="wheel-global-inq-label">in questions</span>
+                            <span class="wheel-global-inq-value" id="wheelGlobalInQuestionValue">00 : 00</span>
+                        </span>
                     </div>
                     <span class="section-title darker">Questions
                         <button class="wheel-stats-btn" id="wheelStatsBtn" title="Show rating statistics" hidden>📊</button>

--- a/index.html
+++ b/index.html
@@ -271,10 +271,8 @@
 
             <div class="uk-width-1-4@l uk-width-1-5@xl">
                 <div class="sidebar">
-                    <span class="section-title darker wheel-time-section" id="wheelTimeSection" hidden>Time</span>
-                    <span class="timer wheel-timer" id="wheelTimer" hidden>00 : 00</span>
-
                     <span class="section-title darker">Questions
+                        <button class="wheel-stats-btn" id="wheelStatsBtn" title="Show rating statistics" hidden>📊</button>
                         <button class="wheel-showall-btn" id="wheelShowAllBtn" title="Hide all questions">⦸</button>
                         <button class="wheel-search-btn" id="wheelSearchBtn" title="Search questions"><span uk-icon="search"></span></button>
                         <button class="wheel-shuffle-header-btn" id="wheelShuffleBtn" title="Randomize wheel section order">⇄</button>
@@ -308,15 +306,21 @@
                     <button id="wheelModalHide" class="uk-button uk-button-danger" type="button">Hide question</button>
                 </div>
             </div>
-            <div id="wheelMembersPanel" hidden>
-                <div class="wheel-members-panel-header">
-                    <span>Members</span>
-                    <button type="button" id="wheelMembersRollBtn" class="wheel-members-roll-btn" title="Pick a random member who hasn't answered yet">Roll</button>
+            <div id="wheelModalSide" hidden>
+                <div id="wheelModalTimerBox" class="wheel-modal-timer-box" hidden>
+                    <span class="wheel-modal-timer-label">Time</span>
+                    <span class="timer wheel-modal-timer" id="wheelModalTimer">00 : 00</span>
                 </div>
-                <div id="wheelMembersRollResult" class="wheel-members-roll-result" hidden></div>
-                <div id="wheelMembersPanelList" class="wheel-members-panel-list"></div>
-                <div id="wheelMembersPanelEmpty" class="wheel-members-panel-empty" hidden>
-                    No members yet. Add some with the members button next to the gear icon.
+                <div id="wheelMembersPanel" hidden>
+                    <div class="wheel-members-panel-header">
+                        <span>Members</span>
+                        <button type="button" id="wheelMembersRollBtn" class="wheel-members-roll-btn" title="Pick a random member who hasn't answered yet">Roll</button>
+                    </div>
+                    <div id="wheelMembersRollResult" class="wheel-members-roll-result" hidden></div>
+                    <div id="wheelMembersPanelList" class="wheel-members-panel-list"></div>
+                    <div id="wheelMembersPanelEmpty" class="wheel-members-panel-empty" hidden>
+                        No members yet. Add some with the members button next to the gear icon.
+                    </div>
                 </div>
             </div>
         </div>
@@ -330,6 +334,18 @@
                 <button type="button" id="wheelMemberDetailClose" class="wheel-member-detail-close" title="Close">&times;</button>
             </div>
             <div id="wheelMemberDetailBody" class="wheel-member-detail-body"></div>
+        </div>
+    </div>
+
+    <!-- Rating statistics table -->
+    <div id="wheelStatsModal" hidden>
+        <div id="wheelStatsContent">
+            <div class="wheel-stats-header">
+                <span class="wheel-stats-title">Rating statistics</span>
+                <select id="wheelStatsSelect" class="wheel-stats-select" title="Show the global average or a single member"></select>
+                <button type="button" id="wheelStatsClose" class="wheel-member-detail-close" title="Close">&times;</button>
+            </div>
+            <div id="wheelStatsBody" class="wheel-stats-body"></div>
         </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -271,6 +271,12 @@
 
             <div class="uk-width-1-4@l uk-width-1-5@xl">
                 <div class="sidebar">
+                    <div class="wheel-global-timer-box" id="wheelGlobalTimerBox" hidden>
+                        <span class="section-title darker wheel-global-timer-title">Total time
+                            <button class="pause-toggle-btn wheel-global-pause-btn" id="wheelGlobalPauseBtn" type="button" title="Pause/Continue total timer">⏸</button>
+                        </span>
+                        <span class="timer wheel-global-timer" id="wheelGlobalTimer">00 : 00</span>
+                    </div>
                     <span class="section-title darker">Questions
                         <button class="wheel-stats-btn" id="wheelStatsBtn" title="Show rating statistics" hidden>📊</button>
                         <button class="wheel-showall-btn" id="wheelShowAllBtn" title="Hide all questions">⦸</button>
@@ -308,8 +314,12 @@
             </div>
             <div id="wheelModalSide" hidden>
                 <div id="wheelModalTimerBox" class="wheel-modal-timer-box" hidden>
-                    <span class="wheel-modal-timer-label">Time</span>
+                    <span class="wheel-modal-timer-label">Question time</span>
                     <span class="timer wheel-modal-timer" id="wheelModalTimer">00 : 00</span>
+                    <div class="wheel-modal-timer-controls">
+                        <button type="button" id="wheelModalTimerPauseBtn" class="wheel-modal-timer-btn" title="Pause/Continue">⏸</button>
+                        <button type="button" id="wheelModalTimerResetBtn" class="wheel-modal-timer-btn" title="Reset to 00 : 00">↺</button>
+                    </div>
                 </div>
                 <div id="wheelMembersPanel" hidden>
                     <div class="wheel-members-panel-header">

--- a/js/index.js
+++ b/js/index.js
@@ -229,6 +229,17 @@ function getMemberAverageScore(qid) {
     return Math.round(avg * 2) / 2;
 }
 
+// Average rating a single member gave across all questions in `questions`.
+// Returns 0 when they haven't rated anything.
+function getMemberOverallAverage(memberId, questions) {
+    let vals = (questions || [])
+        .map(q => getMemberQuestionScore(q.id, memberId))
+        .filter(v => v > 0);
+    if (vals.length === 0) return 0;
+    let avg = vals.reduce((a, b) => a + b, 0) / vals.length;
+    return Math.round(avg * 2) / 2;
+}
+
 
 // ── Session persistence ──────────────────────────────────────────────────────
 

--- a/js/wheel.js
+++ b/js/wheel.js
@@ -106,6 +106,9 @@ const WHEEL_DEFAULT_PREFS = {
     dynamicRotation: false,
     centered: true,
     timerEnabled: false,
+    // 'always' (default) ticks the global timer continuously;
+    // 'in-question' only counts while a question is open.
+    timerContinuous: true,
     membersEnabled: false,
 };
 
@@ -125,6 +128,7 @@ function loadWheelPrefs() {
                 dynamicRotation: p.dynamicRotation === true,
                 centered:        p.centered !== false,
                 timerEnabled:    p.timerEnabled === true,
+                timerContinuous: p.timerContinuous !== false,
                 membersEnabled:  p.membersEnabled === true,
             };
         }
@@ -574,13 +578,26 @@ class QuestionsWheel {
 
         let timerSwitch = document.getElementById('wheelTimerSwitch');
         let timerRow = document.getElementById('wheelTimerRow');
+        let timerContSwitch = document.getElementById('wheelTimerContinuousSwitch');
+        let timerContRow = document.getElementById('wheelTimerContinuousRow');
         let updateTimerSwitch = () => timerSwitch && timerSwitch.classList.toggle('on', this.prefs.timerEnabled);
+        let updateTimerContSwitch = () => {
+            timerContSwitch && timerContSwitch.classList.toggle('on', this.prefs.timerContinuous);
+            // The "Count always" sub-option is only meaningful when the
+            // timer feature itself is enabled.
+            if (timerContRow) {
+                timerContRow.style.opacity = this.prefs.timerEnabled ? '' : '0.38';
+                timerContRow.style.pointerEvents = this.prefs.timerEnabled ? '' : 'none';
+            }
+        };
         updateTimerSwitch();
+        updateTimerContSwitch();
         if (timerRow) {
             timerRow.onclick = (e) => {
                 e.preventDefault();
                 this.prefs.timerEnabled = !this.prefs.timerEnabled;
                 updateTimerSwitch();
+                updateTimerContSwitch();
                 saveWheelPrefs(this.prefs);
                 this.applyTimerVisibility();
                 // If a question is open, the timer should start counting
@@ -592,6 +609,16 @@ class QuestionsWheel {
                     if (side) side.hidden = false;
                     this.startTimer();
                 }
+            };
+        }
+        if (timerContRow) {
+            timerContRow.onclick = (e) => {
+                e.preventDefault();
+                if (!this.prefs.timerEnabled) return;
+                this.prefs.timerContinuous = !this.prefs.timerContinuous;
+                updateTimerContSwitch();
+                saveWheelPrefs(this.prefs);
+                this.applyTimerVisibility();
             };
         }
 
@@ -1747,9 +1774,22 @@ class QuestionsWheel {
         if (box) box.hidden = !on;
         let globalBox = document.getElementById('wheelGlobalTimerBox');
         if (globalBox) globalBox.hidden = !on;
+        // The small in-question secondary readout only makes sense in
+        // continuous mode (otherwise it would just mirror the main timer).
+        let inq = document.getElementById('wheelGlobalInQuestion');
+        if (inq) inq.hidden = !(on && this.prefs.timerContinuous);
         this.applyModalSideVisibility();
-        // Render once so the labels are correct even without a tick.
+        // In continuous mode the global timer keeps ticking; in in-question
+        // mode it only ticks while a question is open.
+        this.initTimers();
+        if (on && this.prefs.timerContinuous && !this.global.paused) {
+            this.swStart(this.global);
+            this.ensureTimerLoop();
+        } else if (on && !this.prefs.timerContinuous && !this.selected) {
+            this.swStop(this.global);
+        }
         this.renderTimers();
+        this.stopTimerLoopIfIdle();
     }
 
     applyModalSideVisibility() {
@@ -1770,6 +1810,7 @@ class QuestionsWheel {
     initTimers() {
         this.global = this.global || { elapsed: 0, runSince: null, paused: false };
         this.question = this.question || { elapsed: 0, runSince: null, paused: false };
+        this.inQuestion = this.inQuestion || { elapsed: 0, runSince: null, paused: false };
     }
 
     stopwatchValue(s) {
@@ -1799,6 +1840,8 @@ class QuestionsWheel {
         if (gEl) gEl.innerText = this.formatTime(this.stopwatchValue(this.global));
         let qEl = document.getElementById('wheelModalTimer');
         if (qEl) qEl.innerText = this.formatTime(this.stopwatchValue(this.question));
+        let inqEl = document.getElementById('wheelGlobalInQuestionValue');
+        if (inqEl) inqEl.innerText = this.formatTime(this.stopwatchValue(this.inQuestion));
 
         let gBtn = document.getElementById('wheelGlobalPauseBtn');
         if (gBtn) gBtn.innerText = this.global.paused ? '▶' : '⏸';
@@ -1819,22 +1862,25 @@ class QuestionsWheel {
     }
 
     stopTimerLoopIfIdle() {
-        // Keep the loop while either stopwatch is actively running.
-        if (this.global.runSince != null || this.question.runSince != null) return;
+        // Keep the loop while any stopwatch is actively running.
+        if (this.global.runSince != null
+            || this.question.runSince != null
+            || this.inQuestion.runSince != null) return;
         if (this.timerInterval) clearInterval(this.timerInterval);
         this.timerInterval = null;
     }
 
     // Called when a question modal opens. Resets the question timer; starts
-    // both stopwatches (subject to their own pause state).
+    // the per-question and in-question stopwatches. In 'in-question' mode
+    // the global also starts now (in continuous mode it's already running).
     startTimer() {
         this.initTimers();
         if (!this.prefs.timerEnabled) return;
-        // Reset question stopwatch for the new question.
         this.question.elapsed = 0;
         this.question.runSince = null;
         this.question.paused = false;
         this.swStart(this.question);
+        this.swStart(this.inQuestion);
         this.swStart(this.global);
         this.ensureTimerLoop();
         this.renderTimers();
@@ -1844,7 +1890,10 @@ class QuestionsWheel {
     stopTimer() {
         this.initTimers();
         this.swStop(this.question);
-        this.swStop(this.global);
+        this.swStop(this.inQuestion);
+        // The continuous global timer keeps ticking once no question is open;
+        // the in-question one stops with the modal.
+        if (!this.prefs.timerContinuous) this.swStop(this.global);
         this.renderTimers();
         this.stopTimerLoopIfIdle();
     }

--- a/js/wheel.js
+++ b/js/wheel.js
@@ -314,6 +314,7 @@ class QuestionsWheel {
     }
 
     attach() {
+        this.initTimers();
         this.applySize();
         this.applyTextScale();
         this.applyHubSize();
@@ -322,6 +323,13 @@ class QuestionsWheel {
 
         let hub = document.getElementById('wheelHub');
         if (hub) hub.onclick = () => this.spin();
+
+        let globalPauseBtn = document.getElementById('wheelGlobalPauseBtn');
+        if (globalPauseBtn) globalPauseBtn.onclick = () => this.toggleGlobalPause();
+        let qPauseBtn = document.getElementById('wheelModalTimerPauseBtn');
+        if (qPauseBtn) qPauseBtn.onclick = () => this.toggleQuestionPause();
+        let qResetBtn = document.getElementById('wheelModalTimerResetBtn');
+        if (qResetBtn) qResetBtn.onclick = () => this.resetQuestionTimer();
 
         document.getElementById('wheelModalClose').onclick = () => {
             playSound('next');
@@ -1053,6 +1061,8 @@ class QuestionsWheel {
             + (answered.length === 1 ? '' : 's') + ' answered';
         body.appendChild(summary);
 
+        let avgOf = vals => Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 2) / 2;
+
         groupNames.forEach(name => {
             let qs = buckets[name].slice().sort((a, b) => titleOf(a).localeCompare(titleOf(b)));
             let grpObj = this.groups.find(g => g.name === name);
@@ -1074,6 +1084,16 @@ class QuestionsWheel {
             gcount.textContent = '(' + qs.length + ')';
             head.appendChild(dot);
             head.appendChild(gname);
+            if (isScoringEnabled()) {
+                let gvals = qs.map(q => getMemberQuestionScore(q.id, memberId)).filter(v => v > 0);
+                if (gvals.length > 0) {
+                    let gavg = document.createElement('span');
+                    gavg.className = 'wheel-member-detail-group-avg';
+                    gavg.textContent = '★' + avgOf(gvals);
+                    gavg.title = 'Average rating for ' + name;
+                    head.appendChild(gavg);
+                }
+            }
             head.appendChild(gcount);
             section.appendChild(head);
 
@@ -1098,6 +1118,27 @@ class QuestionsWheel {
             });
             body.appendChild(section);
         });
+
+        if (isScoringEnabled()) {
+            let allVals = answered
+                .map(q => getMemberQuestionScore(q.id, memberId))
+                .filter(v => v > 0);
+            if (allVals.length > 0) {
+                let footer = document.createElement('div');
+                footer.className = 'wheel-member-detail-footer';
+                let label = document.createElement('span');
+                label.className = 'wheel-member-detail-footer-label';
+                label.textContent = 'Overall average';
+                let val = document.createElement('span');
+                val.className = 'wheel-member-detail-footer-avg';
+                val.textContent = '★' + avgOf(allVals);
+                val.title = 'Average across ' + allVals.length + ' rated question'
+                    + (allVals.length === 1 ? '' : 's');
+                footer.appendChild(label);
+                footer.appendChild(val);
+                body.appendChild(footer);
+            }
+        }
 
         modal.hidden = false;
         playSound('navigate');
@@ -1720,11 +1761,14 @@ class QuestionsWheel {
     }
 
     applyTimerVisibility() {
-        // Timer now lives in the modal side panel, not the sidebar.
-        // Show/hide the timer box inside the modal based on the pref.
+        let on = this.prefs.timerEnabled;
         let box = document.getElementById('wheelModalTimerBox');
-        if (box) box.hidden = !this.prefs.timerEnabled;
+        if (box) box.hidden = !on;
+        let globalBox = document.getElementById('wheelGlobalTimerBox');
+        if (globalBox) globalBox.hidden = !on;
         this.applyModalSideVisibility();
+        // Render once so the labels are correct even without a tick.
+        this.renderTimers();
     }
 
     applyModalSideVisibility() {
@@ -1736,30 +1780,115 @@ class QuestionsWheel {
         side.hidden = !(timerOn || membersOpen);
     }
 
-    startTimer() {
-        if (!this.prefs.timerEnabled) return;
-        if (this.timerInterval) return;
-        this.timerStart = Date.now();
-        let render = () => {
-            let el = document.getElementById('wheelModalTimer');
-            if (!el) return;
-            let ms = Date.now() - this.timerStart;
-            let s = Math.floor(ms / 1000);
-            let m = Math.floor(s / 60);
-            let h = Math.floor(m / 60);
-            el.innerText = (h > 0 ? String(h).padStart(2, '0') + ' : ' : '')
-                + String(m % 60).padStart(2, '0') + ' : '
-                + String(s % 60).padStart(2, '0');
-        };
-        render();
-        this.timerInterval = setInterval(render, 500);
+    // ── Timers ────────────────────────────────────────────────────────────────
+    // Two independent stopwatches: a global one (total time spent in questions)
+    // and a per-question one (resets on each question open). Each ticks while
+    // its `runSince` is non-null and stops while paused or while no question
+    // is open. The global timer also stops when its own pause is engaged.
+
+    initTimers() {
+        this.global = this.global || { elapsed: 0, runSince: null, paused: false };
+        this.question = this.question || { elapsed: 0, runSince: null, paused: false };
     }
 
-    stopTimer() {
+    stopwatchValue(s) {
+        return s.elapsed + (s.runSince != null ? Date.now() - s.runSince : 0);
+    }
+
+    formatTime(ms) {
+        let s = Math.floor(ms / 1000);
+        let m = Math.floor(s / 60);
+        let h = Math.floor(m / 60);
+        return (h > 0 ? String(h).padStart(2, '0') + ' : ' : '')
+            + String(m % 60).padStart(2, '0') + ' : '
+            + String(s % 60).padStart(2, '0');
+    }
+
+    swStart(s) { if (s.runSince == null && !s.paused) s.runSince = Date.now(); }
+    swStop(s) { if (s.runSince != null) { s.elapsed += Date.now() - s.runSince; s.runSince = null; } }
+    swTogglePause(s) {
+        if (s.paused) { s.paused = false; this.swStart(s); }
+        else { this.swStop(s); s.paused = true; }
+    }
+    swReset(s) { s.elapsed = 0; if (s.runSince != null) s.runSince = Date.now(); }
+
+    renderTimers() {
+        this.initTimers();
+        let gEl = document.getElementById('wheelGlobalTimer');
+        if (gEl) gEl.innerText = this.formatTime(this.stopwatchValue(this.global));
+        let qEl = document.getElementById('wheelModalTimer');
+        if (qEl) qEl.innerText = this.formatTime(this.stopwatchValue(this.question));
+
+        let gBtn = document.getElementById('wheelGlobalPauseBtn');
+        if (gBtn) gBtn.innerText = this.global.paused ? '▶' : '⏸';
+        let gTimer = document.getElementById('wheelGlobalTimer');
+        if (gTimer) gTimer.classList.toggle('paused', this.global.paused);
+
+        let qBtn = document.getElementById('wheelModalTimerPauseBtn');
+        if (qBtn) qBtn.innerText = this.question.paused ? '▶' : '⏸';
+        let qTimer = document.getElementById('wheelModalTimer');
+        if (qTimer) qTimer.classList.toggle('paused', this.question.paused);
+    }
+
+    ensureTimerLoop() {
+        if (this.timerInterval) return;
+        let tick = () => this.renderTimers();
+        tick();
+        this.timerInterval = setInterval(tick, 500);
+    }
+
+    stopTimerLoopIfIdle() {
+        // Keep the loop while either stopwatch is actively running.
+        if (this.global.runSince != null || this.question.runSince != null) return;
         if (this.timerInterval) clearInterval(this.timerInterval);
         this.timerInterval = null;
-        let el = document.getElementById('wheelModalTimer');
-        if (el) el.innerText = '00 : 00';
+    }
+
+    // Called when a question modal opens. Resets the question timer; starts
+    // both stopwatches (subject to their own pause state).
+    startTimer() {
+        this.initTimers();
+        if (!this.prefs.timerEnabled) return;
+        // Reset question stopwatch for the new question.
+        this.question.elapsed = 0;
+        this.question.runSince = null;
+        this.question.paused = false;
+        this.swStart(this.question);
+        this.swStart(this.global);
+        this.ensureTimerLoop();
+        this.renderTimers();
+    }
+
+    // Called when the question modal closes.
+    stopTimer() {
+        this.initTimers();
+        this.swStop(this.question);
+        this.swStop(this.global);
+        this.renderTimers();
+        this.stopTimerLoopIfIdle();
+    }
+
+    toggleGlobalPause() {
+        this.initTimers();
+        this.swTogglePause(this.global);
+        playSound('pause');
+        this.renderTimers();
+        this.stopTimerLoopIfIdle();
+    }
+
+    toggleQuestionPause() {
+        this.initTimers();
+        this.swTogglePause(this.question);
+        playSound('pause');
+        this.renderTimers();
+        this.stopTimerLoopIfIdle();
+    }
+
+    resetQuestionTimer() {
+        this.initTimers();
+        this.swReset(this.question);
+        playSound('navigate');
+        this.renderTimers();
     }
 
     updateHubSizeLabel() {

--- a/js/wheel.js
+++ b/js/wheel.js
@@ -337,11 +337,13 @@ class QuestionsWheel {
         };
 
         // Spacebar triggers spin when the modal is not open
-        let anyOverlayOpen = () => ['wheelMemberDetailModal', 'wheelChoiceModal']
+        let anyOverlayOpen = () => ['wheelMemberDetailModal', 'wheelChoiceModal', 'wheelStatsModal']
             .some(id => { let el = document.getElementById(id); return el && !el.hidden; });
 
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') {
+                let stats = document.getElementById('wheelStatsModal');
+                if (stats && !stats.hidden) { this.closeStatsModal(); return; }
                 let detail = document.getElementById('wheelMemberDetailModal');
                 if (detail && !detail.hidden) { this.closeMemberDetail(); return; }
                 let choice = document.getElementById('wheelChoiceModal');
@@ -360,6 +362,16 @@ class QuestionsWheel {
         if (memberDetailModal) memberDetailModal.onclick = (e) => {
             if (e.target === memberDetailModal) this.closeMemberDetail();
         };
+
+        let statsClose = document.getElementById('wheelStatsClose');
+        if (statsClose) statsClose.onclick = () => { playSound('next'); this.closeStatsModal(); };
+        let statsModal = document.getElementById('wheelStatsModal');
+        if (statsModal) statsModal.onclick = (e) => {
+            if (e.target === statsModal) this.closeStatsModal();
+        };
+
+        let statsBtn = document.getElementById('wheelStatsBtn');
+        if (statsBtn) statsBtn.onclick = () => this.openStatsModal();
 
         let choiceCancel = document.getElementById('wheelChoiceCancel');
         if (choiceCancel) choiceCancel.onclick = () => { playSound('next'); this.closeChoice(); };
@@ -482,7 +494,11 @@ class QuestionsWheel {
 
         let scoringSwitch = document.getElementById('wheelScoringSwitch');
         let scoringRow = document.getElementById('wheelScoringRow');
-        let updateScoringSwitch = () => scoringSwitch && scoringSwitch.classList.toggle('on', isScoringEnabled());
+        let updateScoringSwitch = () => {
+            scoringSwitch && scoringSwitch.classList.toggle('on', isScoringEnabled());
+            let sb = document.getElementById('wheelStatsBtn');
+            if (sb) sb.hidden = !isScoringEnabled();
+        };
         updateScoringSwitch();
         if (scoringRow) {
             scoringRow.onclick = (e) => {
@@ -561,8 +577,13 @@ class QuestionsWheel {
                 this.applyTimerVisibility();
                 // If a question is open, the timer should start counting
                 // right away when newly enabled, and stop when disabled.
-                if (!this.prefs.timerEnabled) this.stopTimer();
-                else if (this.selected) this.startTimer();
+                if (!this.prefs.timerEnabled) {
+                    this.stopTimer();
+                } else if (this.selected) {
+                    let side = document.getElementById('wheelModalSide');
+                    if (side) side.hidden = false;
+                    this.startTimer();
+                }
             };
         }
 
@@ -1087,6 +1108,157 @@ class QuestionsWheel {
         if (modal) modal.hidden = true;
     }
 
+    // ── Stats modal ───────────────────────────────────────────────────────────
+
+    openStatsModal() {
+        let modal = document.getElementById('wheelStatsModal');
+        let sel = document.getElementById('wheelStatsSelect');
+        if (!modal || !sel) return;
+
+        // Build dropdown: "Global" + one entry per member.
+        sel.innerHTML = '';
+        let globalOpt = document.createElement('option');
+        globalOpt.value = '';
+        globalOpt.textContent = 'Global average';
+        sel.appendChild(globalOpt);
+        this.members.forEach(m => {
+            let opt = document.createElement('option');
+            opt.value = m.id;
+            opt.textContent = m.name;
+            sel.appendChild(opt);
+        });
+        sel.value = '';
+        sel.onchange = () => this.renderStatsTable(sel.value);
+
+        this.renderStatsTable('');
+        modal.hidden = false;
+        playSound('navigate');
+    }
+
+    renderStatsTable(memberId) {
+        let body = document.getElementById('wheelStatsBody');
+        if (!body) return;
+        body.innerHTML = '';
+
+        let questions = this.questions;
+        if (questions.length === 0) {
+            let empty = document.createElement('div');
+            empty.className = 'wheel-stats-empty';
+            empty.textContent = 'No questions loaded.';
+            body.appendChild(empty);
+            return;
+        }
+
+        let titleOf = q => (q.question && q.question.title) || ('Question #' + q.id);
+        let groupNameOf = q => {
+            let g = this.findGroup(this.questionGroups[q.id]);
+            return g ? g.name : 'Ungrouped';
+        };
+
+        let groupOrder = {};
+        this.groups.forEach((g, i) => { groupOrder[g.name] = i; });
+        let orderIndex = name => (name in groupOrder ? groupOrder[name] : this.groups.length);
+
+        let scoreOf = (q) => {
+            if (memberId) {
+                return getMemberQuestionScore(q.id, memberId);
+            }
+            let manual = getQuestionScore(q.id);
+            return manual > 0 ? manual : getMemberAverageScore(q.id);
+        };
+
+        // Only rows with a score > 0.
+        let rated = questions.filter(q => scoreOf(q) > 0);
+
+        if (rated.length === 0) {
+            let empty = document.createElement('div');
+            empty.className = 'wheel-stats-empty';
+            empty.textContent = memberId
+                ? 'This member hasn\'t rated any questions yet.'
+                : 'No ratings yet.';
+            body.appendChild(empty);
+            return;
+        }
+
+        rated.sort((a, b) => {
+            let ga = groupNameOf(a), gb = groupNameOf(b);
+            let oa = orderIndex(ga), ob = orderIndex(gb);
+            if (oa !== ob) return oa - ob;
+            if (ga !== gb) return ga.localeCompare(gb);
+            return scoreOf(b) - scoreOf(a);
+        });
+
+        // Group rows by category.
+        let buckets = {};
+        rated.forEach(q => {
+            let name = groupNameOf(q);
+            (buckets[name] = buckets[name] || []).push(q);
+        });
+        let groupNames = Object.keys(buckets).sort((a, b) => orderIndex(a) - orderIndex(b));
+
+        // Overall average line.
+        let allVals = rated.map(scoreOf);
+        let overallAvg = Math.round((allVals.reduce((a, b) => a + b, 0) / allVals.length) * 2) / 2;
+        let summary = document.createElement('div');
+        summary.className = 'wheel-stats-summary';
+        summary.textContent = rated.length + ' rated question' + (rated.length === 1 ? '' : 's')
+            + ' · overall avg ★' + overallAvg;
+        body.appendChild(summary);
+
+        groupNames.forEach(name => {
+            let qs = buckets[name];
+            let grpObj = this.groups.find(g => g.name === name);
+
+            let section = document.createElement('div');
+            section.className = 'wheel-stats-group';
+
+            let head = document.createElement('div');
+            head.className = 'wheel-stats-group-head';
+            if (grpObj && grpObj.color) {
+                let dot = document.createElement('span');
+                dot.className = 'wheel-member-detail-dot';
+                dot.style.background = grpObj.color;
+                head.appendChild(dot);
+            }
+            let gname = document.createElement('span');
+            gname.className = 'wheel-stats-group-name';
+            gname.textContent = name;
+            head.appendChild(gname);
+
+            let gvals = qs.map(scoreOf);
+            let gavg = Math.round((gvals.reduce((a, b) => a + b, 0) / gvals.length) * 2) / 2;
+            let gcnt = document.createElement('span');
+            gcnt.className = 'wheel-stats-group-avg';
+            gcnt.textContent = '★' + gavg;
+            head.appendChild(gcnt);
+            section.appendChild(head);
+
+            qs.forEach(q => {
+                let row = document.createElement('div');
+                row.className = 'wheel-stats-row';
+
+                let qtitle = document.createElement('span');
+                qtitle.className = 'wheel-stats-q';
+                qtitle.textContent = titleOf(q);
+
+                let stars = document.createElement('span');
+                stars.className = 'wheel-stats-stars';
+                stars.textContent = '★' + scoreOf(q);
+
+                row.appendChild(qtitle);
+                row.appendChild(stars);
+                section.appendChild(row);
+            });
+
+            body.appendChild(section);
+        });
+    }
+
+    closeStatsModal() {
+        let modal = document.getElementById('wheelStatsModal');
+        if (modal) modal.hidden = true;
+    }
+
     // Small choice dialog. options is [{ label, desc, fn }]; picking one closes
     // the dialog and runs its fn. Used by the Show/Hide question filters.
     showChoice(title, options) {
@@ -1387,6 +1559,8 @@ class QuestionsWheel {
         if (panel.hidden) {
             this.renderMembersPanel();
             panel.hidden = false;
+            let side = document.getElementById('wheelModalSide');
+            if (side) side.hidden = false;
             playSound('navigate');
         } else {
             this.closeMembersPanel();
@@ -1396,6 +1570,7 @@ class QuestionsWheel {
     closeMembersPanel() {
         let panel = document.getElementById('wheelMembersPanel');
         if (panel) panel.hidden = true;
+        this.applyModalSideVisibility();
     }
 
     renderMembersPanel() {
@@ -1463,7 +1638,26 @@ class QuestionsWheel {
                 row.appendChild(buildMemberStarWidget(qid, m.id, () => {
                     this.refreshModalScore();
                     this.renderSidebar();
+                    // Refresh this member's avg badge too.
+                    let avgBadge = row.querySelector('.wheel-member-avg-rating');
+                    if (avgBadge) {
+                        let a = getMemberOverallAverage(m.id, this.questions);
+                        avgBadge.textContent = a > 0 ? '★ ' + a : '';
+                        avgBadge.title = a > 0 ? 'Average rating: ' + a + ' / 5' : 'No ratings yet';
+                    }
                 }));
+            }
+
+            // Show the member's overall average rating across all questions.
+            if (isScoringEnabled()) {
+                let avg = getMemberOverallAverage(m.id, this.questions);
+                let avgBadge = document.createElement('span');
+                avgBadge.className = 'wheel-member-avg-rating';
+                avgBadge.textContent = avg > 0 ? '★ ' + avg : '';
+                avgBadge.title = avg > 0 ? 'Average rating: ' + avg + ' / 5' : 'No ratings yet';
+                avgBadge.onclick = (e) => e.stopPropagation();
+                avgBadge.ondblclick = (e) => e.stopPropagation();
+                row.appendChild(avgBadge);
             }
 
             list.appendChild(row);
@@ -1526,11 +1720,20 @@ class QuestionsWheel {
     }
 
     applyTimerVisibility() {
-        let sec = document.getElementById('wheelTimeSection');
-        let timer = document.getElementById('wheelTimer');
-        let on = this.prefs.timerEnabled;
-        if (sec) sec.hidden = !on;
-        if (timer) timer.hidden = !on;
+        // Timer now lives in the modal side panel, not the sidebar.
+        // Show/hide the timer box inside the modal based on the pref.
+        let box = document.getElementById('wheelModalTimerBox');
+        if (box) box.hidden = !this.prefs.timerEnabled;
+        this.applyModalSideVisibility();
+    }
+
+    applyModalSideVisibility() {
+        let side = document.getElementById('wheelModalSide');
+        if (!side) return;
+        let timerOn = this.prefs.timerEnabled;
+        let panel = document.getElementById('wheelMembersPanel');
+        let membersOpen = panel ? !panel.hidden : false;
+        side.hidden = !(timerOn || membersOpen);
     }
 
     startTimer() {
@@ -1538,7 +1741,7 @@ class QuestionsWheel {
         if (this.timerInterval) return;
         this.timerStart = Date.now();
         let render = () => {
-            let el = document.getElementById('wheelTimer');
+            let el = document.getElementById('wheelModalTimer');
             if (!el) return;
             let ms = Date.now() - this.timerStart;
             let s = Math.floor(ms / 1000);
@@ -1555,7 +1758,7 @@ class QuestionsWheel {
     stopTimer() {
         if (this.timerInterval) clearInterval(this.timerInterval);
         this.timerInterval = null;
-        let el = document.getElementById('wheelTimer');
+        let el = document.getElementById('wheelModalTimer');
         if (el) el.innerText = '00 : 00';
     }
 
@@ -2140,6 +2343,12 @@ class QuestionsWheel {
         let membersPanel = document.getElementById('wheelMembersPanel');
         if (membersPanel) membersPanel.hidden = !this.prefs.membersEnabled;
         this.renderMembersPanel();
+
+        // Show side panel if timer or members are active.
+        let side = document.getElementById('wheelModalSide');
+        if (side) side.hidden = !(this.prefs.timerEnabled || this.prefs.membersEnabled);
+        let timerBox = document.getElementById('wheelModalTimerBox');
+        if (timerBox) timerBox.hidden = !this.prefs.timerEnabled;
 
         modal.hidden = false;
         this.startTimer();

--- a/js/wheel.js
+++ b/js/wheel.js
@@ -1679,26 +1679,7 @@ class QuestionsWheel {
                 row.appendChild(buildMemberStarWidget(qid, m.id, () => {
                     this.refreshModalScore();
                     this.renderSidebar();
-                    // Refresh this member's avg badge too.
-                    let avgBadge = row.querySelector('.wheel-member-avg-rating');
-                    if (avgBadge) {
-                        let a = getMemberOverallAverage(m.id, this.questions);
-                        avgBadge.textContent = a > 0 ? '★ ' + a : '';
-                        avgBadge.title = a > 0 ? 'Average rating: ' + a + ' / 5' : 'No ratings yet';
-                    }
                 }));
-            }
-
-            // Show the member's overall average rating across all questions.
-            if (isScoringEnabled()) {
-                let avg = getMemberOverallAverage(m.id, this.questions);
-                let avgBadge = document.createElement('span');
-                avgBadge.className = 'wheel-member-avg-rating';
-                avgBadge.textContent = avg > 0 ? '★ ' + avg : '';
-                avgBadge.title = avg > 0 ? 'Average rating: ' + avg + ' / 5' : 'No ratings yet';
-                avgBadge.onclick = (e) => e.stopPropagation();
-                avgBadge.ondblclick = (e) => e.stopPropagation();
-                row.appendChild(avgBadge);
             }
 
             list.appendChild(row);


### PR DESCRIPTION
1. Timer box appears as a separate box next to the question (in the modal side panel, above the members list) when timer is enabled. Removed timer from the sidebar.

2. Each member row in the modal panel now shows their overall average star rating across all questions (★ N.N badge, only when scoring is enabled).

3. Added a stats (📊) button next to the Questions heading. Opens a modal table showing average star rating per question, grouped by category. A dropdown lets the host switch between the global view (manual override or member average) and any individual member's own ratings.

https://claude.ai/code/session_016a5uwfC2mciSxG39WjPt8C